### PR TITLE
Enable operation in Python < 3.11

### DIFF
--- a/server/app/plugins/jirastats.py
+++ b/server/app/plugins/jirastats.py
@@ -233,6 +233,7 @@ async def poll_loop():
     loop = asyncio.get_running_loop()
 
     def maybe_timeout(duration):
+        "Use asyncio.timeout() for Py3.11; stub out for lower versions."
         if hasattr(asyncio, 'timeout'):
             return asyncio.timeout(duration)
         import contextlib


### PR DESCRIPTION
The asyncio.timeout() function is only available in Python 3.11. This commit simply ignores the timeout feature if it is not available, allowing operation in lower versions of Python (eg. the default Python available on our Ubuntu 22 boxes).