### PR TITLE
Up worker count; generate logs

### DIFF
--- a/pipservice-reporting-dashboard.service
+++ b/pipservice-reporting-dashboard.service
@@ -5,7 +5,7 @@ Description=ASF Infra Reporting Dashboard
 [Service]
 Type=simple
 WorkingDirectory=/opt/reporting-dashboard/server/
-ExecStart=/usr/local/bin/pipenv run python3.11 -m hypercorn server:application
+ExecStart=/usr/local/bin/pipenv run python3.11 -m hypercorn server:application -w 6 --error-log /var/log/apache2/dashboard-error.log --access-log /var/log/apache2/dashboard-access.log
 Restart=always
 User=www-data
 Group=www-data


### PR DESCRIPTION
Hypercorn defaults to a single worker; this is probably the cause of the frequent timeouts.

Ths PR ups the worker count and generates logs to track any errors