### PR TITLE
Fix GitHub Actions usage overcount for queued jobs

### DIFF
--- a/.github/workflows/type-tests.yml
+++ b/.github/workflows/type-tests.yml
@@ -37,3 +37,6 @@ jobs:
       if: always() # even if mypy fails
       run: |
           pylint --recursive y .
+    - name: Unit tests
+      run: |
+          python -m unittest discover -s tests

--- a/server/app/endpoints/builds.py
+++ b/server/app/endpoints/builds.py
@@ -46,12 +46,12 @@ async def fetch_n_days(hours=MAX_BUILD_SPAN):
                 break
             for row in rowset:
                 row_as_dict = dict(row)
-                # If the job is too old, set 'jobs' entry to empty array, to save memory.
-                # We generally will not need the job data for older entries.
+                row_as_dict["jobs"] = json.loads(row_as_dict["jobs"])
+                ghascanner.normalize_run_row(row_as_dict)
+                # If the job is too old, set 'jobs' entry to empty array after
+                # normalization to save memory without preserving inflated totals.
                 if row_as_dict["run_finish"] < job_data_cutoff:
                     row_as_dict["jobs"] = []
-                else:
-                    row_as_dict["jobs"] = json.loads(row_as_dict["jobs"])
                 temp_cache.append(row_as_dict)
         # Wipe cache, set to new bits
         BUILDS_CACHE.clear()

--- a/server/app/plugins/ghascanner.py
+++ b/server/app/plugins/ghascanner.py
@@ -81,40 +81,7 @@ async def gather_stats(payload):
             async with hc.get(url, headers=headers) as req:
                 if req.status == 200:
                     data = await req.json()
-                    seconds_used = 0
-                    earliest_runner = None
-                    last_finish = None
-                    jobs = []
-                    for job in data["jobs"]:
-                        if job["started_at"] and job["completed_at"]:
-                            start_ts = dateutil.parser.isoparse(job["started_at"]).timestamp()
-                            end_ts = dateutil.parser.isoparse(job["completed_at"]).timestamp()
-                            job_name = job["workflow_name"]
-                            job_name_unique = f"{repo}/{job_name}"
-                            job_time = end_ts - start_ts
-                            seconds_used += job_time
-                            labels = job["labels"]
-                            steps = []
-                            if not earliest_runner or start_ts < earliest_runner:
-                                earliest_runner = start_ts
-                            if not last_finish or last_finish < end_ts:
-                                last_finish = end_ts
-                            for step in job["steps"]:
-                                stepname = step["name"]
-                                step_start_ts = dateutil.parser.isoparse(step["started_at"]).timestamp()
-                                step_end_ts = dateutil.parser.isoparse(step["completed_at"]).timestamp()
-                                step_time = step_end_ts - step_start_ts
-                                steps.append((stepname, step_start_ts, step_time))
-                            jobs.append(
-                                {
-                                    "name": job_name,
-                                    "name_unique": job_name_unique,
-                                    "job_duration": job_time,
-                                    "steps": steps,
-                                    "labels": labels,
-                                    "runner_group": job.get("runner_group_name", "GitHub Actions") or "GitHub Actions",
-                                }
-                            )
+                    seconds_used, earliest_runner, last_finish, jobs = parse_jobs(data, repo)
                     if earliest_runner:
                         run_dict = {
                             "project": project,
@@ -133,6 +100,77 @@ async def gather_stats(payload):
                     await asyncio.sleep(0.2)
     except (json.JSONDecodeError, ValueError):
         pass
+
+
+def job_used_runner(job):
+    """Returns whether a workflow job was assigned to a runner."""
+    return bool(job.get("runner_name"))
+
+
+def stored_job_used_runner(job):
+    """Returns whether a serialized job record should count as runner time."""
+    if "runner_name" in job:
+        return bool(job["runner_name"])
+    # Older stored rows did not include runner_name; queued-only cancellations
+    # observed from GitHub also have no steps, so use steps as the best signal.
+    return bool(job.get("steps"))
+
+
+def normalize_run_row(row):
+    """Adjusts cached DB rows to exclude serialized jobs that never used a runner."""
+    if row.get("jobs"):
+        # Recalculate from the filtered job list so cached rows with previous
+        # queued-time overcounts do not keep returning inflated seconds_used.
+        row["jobs"] = [job for job in row["jobs"] if stored_job_used_runner(job)]
+        row["seconds_used"] = sum(job["job_duration"] for job in row["jobs"])
+    return row
+
+
+def parse_jobs(data, repo):
+    """Calculates runner time from GitHub Actions jobs API data."""
+    seconds_used = 0
+    earliest_runner = None
+    last_finish = None
+    jobs = []
+    for job in data["jobs"]:
+        # GitHub can set started_at/completed_at for jobs that waited in the
+        # queue and were cancelled without ever getting a runner.
+        if not job_used_runner(job):
+            continue
+        if job["started_at"] and job["completed_at"]:
+            start_ts = dateutil.parser.isoparse(job["started_at"]).timestamp()
+            end_ts = dateutil.parser.isoparse(job["completed_at"]).timestamp()
+            job_name = job["workflow_name"]
+            job_name_unique = f"{repo}/{job_name}"
+            job_time = end_ts - start_ts
+            seconds_used += job_time
+            labels = job["labels"]
+            steps = []
+            if not earliest_runner or start_ts < earliest_runner:
+                earliest_runner = start_ts
+            if not last_finish or last_finish < end_ts:
+                last_finish = end_ts
+            for step in job["steps"]:
+                # Some job records can include incomplete step timestamp data;
+                # skip only that step while keeping the job's runner time.
+                if step["started_at"] and step["completed_at"]:
+                    stepname = step["name"]
+                    step_start_ts = dateutil.parser.isoparse(step["started_at"]).timestamp()
+                    step_end_ts = dateutil.parser.isoparse(step["completed_at"]).timestamp()
+                    step_time = step_end_ts - step_start_ts
+                    steps.append((stepname, step_start_ts, step_time))
+            jobs.append(
+                {
+                    "name": job_name,
+                    "name_unique": job_name_unique,
+                    "job_duration": job_time,
+                    "steps": steps,
+                    "labels": labels,
+                    "runner_name": job.get("runner_name", ""),
+                    "runner_group": job.get("runner_group_name", "GitHub Actions") or "GitHub Actions",
+                }
+            )
+    return seconds_used, earliest_runner, last_finish, jobs
 
 
 async def scan_builds():

--- a/tests/test_ghascanner.py
+++ b/tests/test_ghascanner.py
@@ -1,0 +1,137 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+class GhaScannerTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.ghascanner = load_ghascanner()
+
+    def test_parse_jobs_counts_only_jobs_assigned_to_runners(self):
+        data = {
+            "jobs": [
+                {
+                    "name": "real macOS job",
+                    "workflow_name": "Java CI",
+                    "runner_name": "GitHub Actions 1019729395",
+                    "runner_group_name": "GitHub Actions",
+                    "started_at": "2026-06-02T15:59:43Z",
+                    "completed_at": "2026-06-02T16:00:02Z",
+                    "steps": [
+                        {
+                            "name": "Set up job",
+                            "started_at": "2026-06-02T15:59:43Z",
+                            "completed_at": "2026-06-02T15:59:44Z",
+                        }
+                    ],
+                    "labels": ["macos-latest"],
+                    "conclusion": "failure",
+                },
+                {
+                    "name": "queued cancelled job without runner",
+                    "workflow_name": "Java CI",
+                    "runner_name": "",
+                    "runner_group_name": None,
+                    "started_at": "2026-06-01T15:59:28Z",
+                    "completed_at": "2026-06-02T15:59:28Z",
+                    "steps": [],
+                    "labels": ["missing-runner"],
+                    "conclusion": "cancelled",
+                },
+                {
+                    "name": "cancelled after runner assignment",
+                    "workflow_name": "Java CI",
+                    "runner_name": "GitHub Actions 123",
+                    "runner_group_name": "GitHub Actions",
+                    "started_at": "2026-06-04T07:53:03Z",
+                    "completed_at": "2026-06-04T07:55:30Z",
+                    "steps": [
+                        {
+                            "name": "Set up job",
+                            "started_at": "2026-06-04T07:53:03Z",
+                            "completed_at": "2026-06-04T07:53:04Z",
+                        }
+                    ],
+                    "labels": ["ubuntu-latest"],
+                    "conclusion": "cancelled",
+                },
+            ]
+        }
+
+        seconds_used, earliest_runner, last_finish, jobs = self.ghascanner.parse_jobs(data, "mina")
+
+        self.assertEqual(seconds_used, 166)
+        self.assertEqual(len(jobs), 2)
+        self.assertEqual([job["job_duration"] for job in jobs], [19, 147])
+        self.assertEqual([job["runner_name"] for job in jobs], ["GitHub Actions 1019729395", "GitHub Actions 123"])
+        self.assertEqual(earliest_runner, 1780415983)
+        self.assertEqual(last_finish, 1780559730)
+
+    def test_normalize_run_row_filters_legacy_no_runner_jobs(self):
+        row = {
+            "seconds_used": 24 * 3600 + 19,
+            "jobs": [
+                {
+                    "name": "Java CI",
+                    "job_duration": 19,
+                    "steps": [("Set up job", 1780415983, 1)],
+                    "labels": ["macos-latest"],
+                },
+                {
+                    "name": "Java CI",
+                    "job_duration": 24 * 3600,
+                    "steps": [],
+                    "labels": ["missing-runner"],
+                },
+            ],
+        }
+
+        normalized = self.ghascanner.normalize_run_row(row)
+
+        self.assertEqual(len(normalized["jobs"]), 1)
+        self.assertEqual(normalized["seconds_used"], sum(job["job_duration"] for job in normalized["jobs"]))
+        self.assertFalse(any(not job.get("steps") for job in normalized["jobs"]))
+
+
+def load_ghascanner():
+    repo_root = Path(__file__).resolve().parents[1]
+    module_path = repo_root / "server" / "app" / "plugins" / "ghascanner.py"
+
+    aiohttp = types.ModuleType("aiohttp")
+    aiohttp.ClientTimeout = lambda *args, **kwargs: None
+    aiohttp.ClientSession = object
+    aiohttp.ClientError = Exception
+    sys.modules.setdefault("aiohttp", aiohttp)
+
+    asfpy = types.ModuleType("asfpy")
+    asfpy.pubsub = types.ModuleType("asfpy.pubsub")
+    asfpy.sqlite = types.ModuleType("asfpy.sqlite")
+    sys.modules.setdefault("asfpy", asfpy)
+    sys.modules.setdefault("asfpy.pubsub", asfpy.pubsub)
+    sys.modules.setdefault("asfpy.sqlite", asfpy.sqlite)
+
+    server = types.ModuleType("server")
+    server_app = types.ModuleType("server.app")
+    server_app_lib = types.ModuleType("server.app.lib")
+    config = types.ModuleType("server.app.lib.config")
+    plugins = types.ModuleType("server.app.plugins")
+    plugins.root = types.SimpleNamespace(register=lambda *args, **kwargs: None)
+
+    sys.modules.setdefault("server", server)
+    sys.modules.setdefault("server.app", server_app)
+    sys.modules.setdefault("server.app.lib", server_app_lib)
+    sys.modules.setdefault("server.app.lib.config", config)
+    sys.modules.setdefault("server.app.plugins", plugins)
+
+    spec = importlib.util.spec_from_file_location("server.app.plugins.ghascanner", module_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
GitHub Actions job records can contain non-null `started_at` and `completed_at` timestamps even when the job never received a runner. In that state GitHub reports runner_name as empty and steps as empty, but the dashboard previously calculated usage as `completed_at - started_at` for every completed job timestamp pair. Jobs cancelled after waiting for unavailable capacity or impossible runner labels could therefore add days of wall-clock queue time to runner-minute usage.

Count runner usage only for jobs with a non-empty `runner_name`, while still counting cancelled jobs that were actually assigned to a runner. Store `runner_name` in serialized job records so future API responses can make the same distinction.

Normalize cached DB rows before returning API data. For new records this uses `runner_name`; for legacy serialized records that do not have `runner_name`, it falls back to empty steps as the no-runner signal. This lets detailed cached rows stop preserving inflated `seconds_used` values.

Add regression coverage for real runner jobs, queued/cancelled no-runner jobs, cancelled jobs after runner assignment, and legacy cached row normalization.

Generated-By: Codex-5.5 w/ my review