### PR TITLE
ghactions usage: Harden projects-list fetching

### DIFF
--- a/.github/workflows/type-tests.yml
+++ b/.github/workflows/type-tests.yml
@@ -37,3 +37,6 @@ jobs:
       if: always() # even if mypy fails
       run: |
           pylint --recursive y .
+    - name: Unit tests
+      run: |
+          python -m unittest discover -s tests

--- a/server/app/endpoints/builds.py
+++ b/server/app/endpoints/builds.py
@@ -94,7 +94,7 @@ async def show_gha_stats():
             row.pop('jobs', '')
         rows.append(row)
     return {
-        "all_projects": ghascanner.projects,
+        "all_projects": ghascanner.get_projects(),
         "selected_project": project,
         "builds": rows,
     }

--- a/server/app/plugins/ghascanner.py
+++ b/server/app/plugins/ghascanner.py
@@ -41,8 +41,9 @@ CREATE_RUNS_DB = """CREATE TABLE "runs" (
     PRIMARY KEY("id" AUTOINCREMENT)
 );"""
 DEFAULT_PROJECTS_LIST = "https://whimsy.apache.org/public/public_ldap_projects.json"
+PROJECTS_LIST_RETRY_SECONDS = 300
 MAX_DB_ENTRIES = 1000000  # Max 1 million entries in the db
-projects = []
+_projects: list[str] = []
 
 token = ""
 db = None
@@ -149,19 +150,32 @@ async def scan_builds():
             print(f"GitHub Actions poll failed: {e}")
 
 
-async def list_projects():
-    global projects
+async def _fetch_projects_attempt():
+    global _projects
     """Grabs a list of all projects from whimsy"""
     async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as hc:
         try:
             async with hc.get(DEFAULT_PROJECTS_LIST) as req:
                 if req.status == 200:
-                    projects = list((await req.json())["projects"].keys())
-        except (aiohttp.ClientError, asyncio.TimeoutError, json.JSONDecodeError) as e:
+                    _projects = list((await req.json())["projects"].keys())
+                    print(f"GHA stats: loaded {len(_projects)} projects from Whimsy")
+                    return True
+                else:
+                    print(f"GHA stats: Whimsy returned HTTP/{req.status}: {req.reason}")
+        except Exception as e:
             print(f"GHA stats: Could not fetch list of projects from {DEFAULT_PROJECTS_LIST}: {e}")
+    return False
 
+
+async def _fetch_projects():
+    while not await _fetch_projects_attempt():
+        await asyncio.sleep(PROJECTS_LIST_RETRY_SECONDS)
+
+
+def get_projects():
+    return _projects
 
 
 plugins.root.register(
-    scan_builds, list_projects, slug="ghactions", title="GitHub Actions Usage", icon="bi-github", private=True
+    scan_builds, _fetch_projects, slug="ghactions", title="GitHub Actions Usage", icon="bi-github", private=True
 )

--- a/tests/test_ghascanner_projects.py
+++ b/tests/test_ghascanner_projects.py
@@ -1,0 +1,123 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+class FetchProjectsTest(unittest.IsolatedAsyncioTestCase):
+    # The retry helper is intentionally private; these tests exercise it directly to avoid
+    # sleeping through the public retry loop.
+    # pylint: disable=protected-access
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ghascanner = load_ghascanner()
+
+    async def test_fetch_projects_attempt_populates_projects_on_success(self):
+        self.ghascanner._projects = []
+        self.ghascanner.aiohttp.ClientSession = fake_session_factory(
+            FakeResponse(200, {"projects": {"cassandra": {}, "polaris": {}}})
+        )
+
+        ok = await self.ghascanner._fetch_projects_attempt()
+
+        self.assertTrue(ok)
+        self.assertEqual(self.ghascanner.get_projects(), ["cassandra", "polaris"])
+
+    async def test_fetch_projects_attempt_returns_false_on_non_200(self):
+        self.ghascanner._projects = ["existing"]
+        self.ghascanner.aiohttp.ClientSession = fake_session_factory(
+            FakeResponse(503, {}, reason="Service Unavailable")
+        )
+
+        ok = await self.ghascanner._fetch_projects_attempt()
+
+        self.assertFalse(ok)
+        self.assertEqual(self.ghascanner.get_projects(), ["existing"])
+
+    async def test_fetch_projects_attempt_returns_false_on_missing_projects_key(self):
+        self.ghascanner._projects = ["existing"]
+        self.ghascanner.aiohttp.ClientSession = fake_session_factory(
+            FakeResponse(200, {"not_projects": {}})
+        )
+
+        ok = await self.ghascanner._fetch_projects_attempt()
+
+        self.assertFalse(ok)
+        self.assertEqual(self.ghascanner.get_projects(), ["existing"])
+
+
+class FakeClientSession:
+    def __init__(self, response):
+        self.response = response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def get(self, _url):
+        return self.response
+
+
+class FakeResponse:
+    def __init__(self, status, payload, reason="OK"):
+        self.status = status
+        self.payload = payload
+        self.reason = reason
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def json(self):
+        return self.payload
+
+
+def fake_session_factory(response):
+    return lambda *args, **kwargs: FakeClientSession(response)
+
+
+def load_ghascanner():
+    repo_root = Path(__file__).resolve().parents[1]
+    module_path = repo_root / "server" / "app" / "plugins" / "ghascanner.py"
+
+    aiohttp = types.ModuleType("aiohttp")
+    aiohttp.ClientTimeout = lambda *args, **kwargs: None
+    aiohttp.ClientSession = None
+    aiohttp.ClientError = Exception
+    sys.modules["aiohttp"] = aiohttp
+
+    asfpy = types.ModuleType("asfpy")
+    asfpy.pubsub = types.ModuleType("asfpy.pubsub")
+    asfpy.sqlite = types.ModuleType("asfpy.sqlite")
+    sys.modules["asfpy"] = asfpy
+    sys.modules["asfpy.pubsub"] = asfpy.pubsub
+    sys.modules["asfpy.sqlite"] = asfpy.sqlite
+
+    server = types.ModuleType("server")
+    server_app = types.ModuleType("server.app")
+    server_app_lib = types.ModuleType("server.app.lib")
+    config = types.ModuleType("server.app.lib.config")
+    plugins = types.ModuleType("server.app.plugins")
+    plugins.root = types.SimpleNamespace(register=lambda *args, **kwargs: None)
+
+    sys.modules["server"] = server
+    sys.modules["server.app"] = server_app
+    sys.modules["server.app.lib"] = server_app_lib
+    sys.modules["server.app.lib.config"] = config
+    sys.modules["server.app.plugins"] = plugins
+
+    spec = importlib.util.spec_from_file_location("server.app.plugins.ghascanner", module_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The global `projects` variable in `ghascanner.py` appears to be empty on https://infra-reports.apache.org/#ghactions, leaving the projects dropdown list empty ("All projects").

This change attempts to harden the async fetch of the projects list from Whimsey and adds some logging around it. Failed fetch attempts will be retried after 5 minutes.

Generated-By: Codex-5.5 (parts or this work)